### PR TITLE
Update compiler options

### DIFF
--- a/.github/workflows/jazzy-downstream-build.yml
+++ b/.github/workflows/jazzy-downstream-build.yml
@@ -25,3 +25,17 @@ jobs:
       # we don't test the downstream packages, we just try to build it
       downstream_workspace: ros_controls.rolling.repos
       not_test_downstream: true
+  stack-build-clang:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    with:
+      ros_distro: jazzy
+      ros_repo: testing
+      ref_for_scheduled_build: master
+      additional_debs: clang
+      c_compiler: clang
+      cxx_compiler: clang++
+      # we don't test target_workspace, we just build it
+      not_test_build: true
+      # we don't test the downstream packages, we just try to build it
+      downstream_workspace: ros_controls.jazzy.repos
+      not_test_downstream: true

--- a/.github/workflows/rolling-downstream-build.yml
+++ b/.github/workflows/rolling-downstream-build.yml
@@ -25,3 +25,17 @@ jobs:
       # we don't test the downstream packages, we just try to build it
       downstream_workspace: ros_controls.rolling.repos
       not_test_downstream: true
+  stack-build-clang:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    with:
+      ros_distro: rolling
+      ros_repo: testing
+      ref_for_scheduled_build: master
+      additional_debs: clang
+      c_compiler: clang
+      cxx_compiler: clang++
+      # we don't test target_workspace, we just build it
+      not_test_build: true
+      # we don't test the downstream packages, we just try to build it
+      downstream_workspace: ros_controls.rolling.repos
+      not_test_downstream: true

--- a/ros2_control_cmake/cmake/ros2_control.cmake
+++ b/ros2_control_cmake/cmake/ros2_control.cmake
@@ -64,6 +64,12 @@ macro(set_compiler_options)
         add_compile_options(-Werror=range-loop-construct)
       endif()
     endif()
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "(Clang)")
+      add_compile_options(
+        -Wshadow=all
+      )
+    endif()
   endif()
 endmacro()
 

--- a/ros2_control_cmake/cmake/ros2_control.cmake
+++ b/ros2_control_cmake/cmake/ros2_control.cmake
@@ -36,7 +36,6 @@ macro(set_compiler_options)
   if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     add_compile_options(-Wall -Wextra -Wpedantic
                         -Wshadow -Wconversion -Wold-style-cast
-                        -Wsign-conversion  # noisy with gmock headers
                         -Werror=conversion
                         -Werror=format
                         -Werror=missing-braces

--- a/ros2_control_cmake/cmake/ros2_control.cmake
+++ b/ros2_control_cmake/cmake/ros2_control.cmake
@@ -34,9 +34,18 @@ endmacro()
 # set compiler options depending on detected compiler
 macro(set_compiler_options)
   if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror=conversion -Werror=unused-but-set-variable
-                        -Werror=return-type -Werror=shadow -Werror=format
-                        -Werror=missing-braces)
+    add_compile_options(-Wall -Wextra -Wpedantic
+                        -Werror=conversion
+                        -Werror=format
+                        -Werror=missing-braces
+                        -Werror=overflow
+                        -Werror=return-type
+                        -Werror=shadow
+                        -Werror=sign-compare
+                        -Werror=unused-but-set-variable
+                        -Werror=unused-const-variable
+                        -Werror=unused-variable
+                        )
     message(STATUS "Compiler warnings enabled for ${CMAKE_CXX_COMPILER_ID}")
 
     # https://docs.ros.org/en/rolling/How-To-Guides/Ament-CMake-Documentation.html#compiler-and-linker-options

--- a/ros2_control_cmake/cmake/ros2_control.cmake
+++ b/ros2_control_cmake/cmake/ros2_control.cmake
@@ -35,7 +35,8 @@ endmacro()
 macro(set_compiler_options)
   if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     add_compile_options(-Wall -Wextra -Wpedantic
-                        -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast
+                        -Wshadow -Wconversion -Wold-style-cast
+                        -Wsign-conversion  # noisy with gmock headers
                         -Werror=conversion
                         -Werror=format
                         -Werror=missing-braces
@@ -44,7 +45,6 @@ macro(set_compiler_options)
                         -Werror=shadow
                         -Werror=sign-compare
                         -Werror=unused-but-set-variable
-                        -Werror=unused-const-variable
                         -Werror=unused-variable
                         )
     message(STATUS "Compiler warnings enabled for ${CMAKE_CXX_COMPILER_ID}")

--- a/ros2_control_cmake/cmake/ros2_control.cmake
+++ b/ros2_control_cmake/cmake/ros2_control.cmake
@@ -35,6 +35,7 @@ endmacro()
 macro(set_compiler_options)
   if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     add_compile_options(-Wall -Wextra -Wpedantic
+                        -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast
                         -Werror=conversion
                         -Werror=format
                         -Werror=missing-braces


### PR DESCRIPTION
See https://github.com/ros-controls/ros2_control_ci/pull/210
I additionally activated Wshadow and others, because -Werror=shadow does not activate it?

I had to deactivate

    -Werror=unused-const-variable # throws errors in gmock headers
    -Wsign-conversion  # noisy with gmock headers

because gmock fail then to build, and we use that too often as well in our.

I'd like to activate also

    set(CMAKE_CXX_EXTENSIONS OFF)

but pal_statistics fail with 
```
warning: ISO C++11 requires at least one argument for the "..." in a variadic macro
  381 |       DEFAULT_REGISTER_ROS2_CONTROL_INTROSPECTION("state_interface." + get_name(), f);
      |                                                                                     ^
```