### PR TITLE
Set CMAKE_CXX_STANDARD to 20

### DIFF
--- a/ros2_control_cmake/cmake/ros2_control.cmake
+++ b/ros2_control_cmake/cmake/ros2_control.cmake
@@ -54,7 +54,7 @@ macro(set_compiler_options)
       set(CMAKE_C_STANDARD 99)
     endif()
     if(NOT CMAKE_CXX_STANDARD)
-      set(CMAKE_CXX_STANDARD 17)
+      set(CMAKE_CXX_STANDARD 20)
     endif()
 
     set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
https://discourse.openrobotics.org/t/ros-2-lyrical-c-version/52551

needs cmake version 3.12
https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html#prop_tgt:CXX_STANDARD