### PR TITLE
Set CMAKE standard flags also on windows

### DIFF
--- a/ros2_control_cmake/cmake/ros2_control.cmake
+++ b/ros2_control_cmake/cmake/ros2_control.cmake
@@ -33,6 +33,17 @@ endmacro()
 
 # set compiler options depending on detected compiler
 macro(set_compiler_options)
+
+  # https://docs.ros.org/en/rolling/How-To-Guides/Ament-CMake-Documentation.html#compiler-and-linker-options
+  if(NOT CMAKE_C_STANDARD)
+    set(CMAKE_C_STANDARD 99)
+  endif()
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 20)
+  endif()
+
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
   if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     add_compile_options(
       -Wall -Wextra -Wpedantic
@@ -48,16 +59,6 @@ macro(set_compiler_options)
       -Werror=unused-variable
     )
     message(STATUS "Compiler warnings enabled for ${CMAKE_CXX_COMPILER_ID}")
-
-    # https://docs.ros.org/en/rolling/How-To-Guides/Ament-CMake-Documentation.html#compiler-and-linker-options
-    if(NOT CMAKE_C_STANDARD)
-      set(CMAKE_C_STANDARD 99)
-    endif()
-    if(NOT CMAKE_CXX_STANDARD)
-      set(CMAKE_CXX_STANDARD 20)
-    endif()
-
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
     # Extract major version if g++ is used
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

I moved the standard flags outside of the GNU|CLANG branch to set it on every platform

### Is this user-facing behavior change?
no

### Did you use Generative AI?
no

### Additional Information
Needed to build https://github.com/ros-controls/ros2_control/issues/3495